### PR TITLE
FSF-3959 feat(mocker_node): path visualization in mocker_node

### DIFF
--- a/src/common_lib/CMakeLists.txt
+++ b/src/common_lib/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(visualization_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(custom_interfaces REQUIRED)
 
 # Enable OpenMP
 find_package(OpenMP)
@@ -37,7 +38,7 @@ set(IMPLEMENTATION_FILES
 )
 
 add_library(${PROJECT_NAME} SHARED ${IMPLEMENTATION_FILES})
-ament_target_dependencies(${PROJECT_NAME} eufs_msgs std_msgs rclcpp visualization_msgs fs_msgs Eigen3)
+ament_target_dependencies(${PROJECT_NAME} eufs_msgs std_msgs rclcpp visualization_msgs fs_msgs Eigen3 custom_interfaces)
 link_directories(${Eigen_INCLUDE_DIRS})
 target_link_libraries(common_lib ${Eigen_LIBRARIES})
 
@@ -76,7 +77,7 @@ if(BUILD_TESTING)
 
   # Unit tests
   ament_add_gtest(${PROJECT_NAME}_test ${TESTFILES} ${IMPLEMENTATION_FILES} TIMEOUT 600)
-  ament_target_dependencies(${PROJECT_NAME}_test eufs_msgs rclcpp fs_msgs std_msgs visualization_msgs Eigen3)
+  ament_target_dependencies(${PROJECT_NAME}_test eufs_msgs rclcpp fs_msgs std_msgs visualization_msgs Eigen3 custom_interfaces)
   target_include_directories(${PROJECT_NAME}_test PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>

--- a/src/common_lib/CMakeLists.txt
+++ b/src/common_lib/CMakeLists.txt
@@ -33,7 +33,7 @@ set(IMPLEMENTATION_FILES
   src/structures/vehicle_state.cpp
   src/sensor_data/wheel_encoders.cpp
   src/sensor_data/imu.cpp
-  src/communication/marker.cpp
+  src/communication/planning.cpp
   src/vehicle_dynamics/bicycle_model.cpp
 )
 

--- a/src/common_lib/include/common_lib/communication/marker.hpp
+++ b/src/common_lib/include/common_lib/communication/marker.hpp
@@ -10,6 +10,8 @@
 #include "std_msgs/msg/color_rgba.hpp"
 #include "visualization_msgs/msg/marker.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
+#include "custom_interfaces/msg/path_point.hpp"
+#include "custom_interfaces/msg/path_point_array.hpp"
 namespace common_lib::communication {
 
 const std::map<std::string, std::array<float, 4>, std::less<>> marker_color_map = {
@@ -168,5 +170,16 @@ visualization_msgs::msg::Marker line_marker_from_structure_array(
 
   return marker;
 }
+
+
+/**
+ * @brief Converts a Path Point Array from Custom Interfaces into a vector of
+ * common_lib path points
+ * @param path_point_array Path Point Array from Custom Interfaces
+ * @return std::vector<common_lib::structures::PathPoint>
+ */ 
+std::vector<common_lib::structures::PathPoint> path_point_array_from_ci_vector(
+    const custom_interfaces::msg::PathPointArray &path_point_array);
+
 
 }  // namespace common_lib::communication

--- a/src/common_lib/include/common_lib/communication/marker.hpp
+++ b/src/common_lib/include/common_lib/communication/marker.hpp
@@ -10,8 +10,7 @@
 #include "std_msgs/msg/color_rgba.hpp"
 #include "visualization_msgs/msg/marker.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
-#include "custom_interfaces/msg/path_point.hpp"
-#include "custom_interfaces/msg/path_point_array.hpp"
+
 namespace common_lib::communication {
 
 const std::map<std::string, std::array<float, 4>, std::less<>> marker_color_map = {
@@ -170,16 +169,6 @@ visualization_msgs::msg::Marker line_marker_from_structure_array(
 
   return marker;
 }
-
-
-/**
- * @brief Converts a Path Point Array from Custom Interfaces into a vector of
- * common_lib path points
- * @param path_point_array Path Point Array from Custom Interfaces
- * @return std::vector<common_lib::structures::PathPoint>
- */ 
-std::vector<common_lib::structures::PathPoint> path_point_array_from_ci_vector(
-    const custom_interfaces::msg::PathPointArray &path_point_array);
 
 
 }  // namespace common_lib::communication

--- a/src/common_lib/include/common_lib/communication/planning.hpp
+++ b/src/common_lib/include/common_lib/communication/planning.hpp
@@ -1,0 +1,16 @@
+#include "custom_interfaces/msg/path_point.hpp"
+#include "custom_interfaces/msg/path_point_array.hpp"
+#include "common_lib/structures/path_point.hpp"
+
+namespace common_lib::communication {
+
+/**
+ * @brief Converts a Path Point Array from Custom Interfaces into a vector of
+ * common_lib path points
+ * @param path_point_array Path Point Array from Custom Interfaces
+ * @return std::vector<common_lib::structures::PathPoint>
+ */ 
+std::vector<common_lib::structures::PathPoint> path_point_array_from_ci_vector(
+    const custom_interfaces::msg::PathPointArray &path_point_array);
+
+}

--- a/src/common_lib/include/common_lib/structures/position.hpp
+++ b/src/common_lib/include/common_lib/structures/position.hpp
@@ -10,4 +10,4 @@ struct Position {
   double euclidean_distance(const Position &other) const;
 };
 bool operator<(const Position &lhs, const Position &rhs);
-};  // namespace common_lib::structures
+}  // namespace common_lib::structures

--- a/src/common_lib/package.xml
+++ b/src/common_lib/package.xml
@@ -15,6 +15,7 @@
   <depend>std_msgs</depend>
   <depend>rclcpp</depend>
   <depend>geometry_msgs</depend>
+  <depend>custom_interfaces</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/common_lib/src/communication/marker.cpp
+++ b/src/common_lib/src/communication/marker.cpp
@@ -3,91 +3,19 @@
 #include "rclcpp/clock.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-// namespace common_lib::communication {
-//
-// visualization_msgs::msg::MarkerArray marker_array_from_cone_array(
-//     std::vector<common_lib::structures::Cone> cone_array, std::string name_space,
-//     std::string frame_id, std::string color, std::string shape, float scale, int action) {
-//   visualization_msgs::msg::MarkerArray marker_array;
-//   std::array<float, 4> color_array = marker_color_map.at(color);
-//
-//   for (size_t i = 0; i < cone_array.size(); ++i) {
-//     visualization_msgs::msg::Marker marker;
-//
-//     marker.header.frame_id = frame_id;
-//     marker.header.stamp = rclcpp::Clock().now();
-//     marker.ns = name_space;
-//     marker.id = i;
-//     marker.type = marker_shape_map.at(shape);
-//     marker.action = action;
-//
-//     marker.pose.orientation.x = 0.0;
-//     marker.pose.orientation.y = 0.0;
-//     marker.pose.orientation.z = 0.0;
-//     marker.pose.orientation.w = 1.0;
-//
-//     marker.pose.position.x = cone_array[i].position.x;
-//     marker.pose.position.y = cone_array[i].position.y;
-//     marker.pose.position.z = 0;
-//
-//     marker.scale.x = scale;
-//     marker.scale.y = scale;
-//     marker.scale.z = scale;
-//
-//     marker.color.r = color_array[0];
-//     marker.color.g = color_array[1];
-//     marker.color.b = color_array[2];
-//     marker.color.a = color_array[3];
-//
-//     marker.lifetime = rclcpp::Duration(std::chrono::duration<double>(5));
-//
-//     marker_array.markers.push_back(marker);
-//   }
-//
-//   return marker_array;
-// }
-//
-// visualization_msgs::msg::MarkerArray marker_array_from_path_point_array(
-//     std::vector<common_lib::structures::PathPoint> path_point_array, std::string name_space,
-//     std::string frame_id, std::string color, std::string shape, float scale, int action) {
-//   visualization_msgs::msg::MarkerArray marker_array;
-//   std::array<float, 4> color_array = marker_color_map.at(color);
-//
-//   for (size_t i = 0; i < path_point_array.size(); ++i) {
-//     visualization_msgs::msg::Marker marker;
-//
-//     marker.header.frame_id = frame_id;
-//     marker.header.stamp = rclcpp::Clock().now();
-//     marker.ns = name_space;
-//     marker.id = i;
-//     marker.type = marker_shape_map.at(shape);
-//     marker.action = action;
-//
-//     marker.pose.orientation.x = 0.0;
-//     marker.pose.orientation.y = 0.0;
-//     marker.pose.orientation.z = 0.0;
-//     marker.pose.orientation.w = 1.0;
-//
-//     marker.pose.position.x = path_point_array[i].position.x;
-//     marker.pose.position.y = path_point_array[i].position.y;
-//     marker.pose.position.z = 0;
-//
-//     marker.scale.x = scale;
-//     marker.scale.y = scale;
-//     marker.scale.z = scale;
-//
-//     marker.color.r = color_array[0];
-//     marker.color.g = color_array[1];
-//     marker.color.b = color_array[2];
-//     marker.color.a = color_array[3];
-//
-//     marker.lifetime = rclcpp::Duration(std::chrono::duration<double>(5));
-//
-//     marker_array.markers.push_back(marker);
-//   }
-//
-//   return marker_array;
-// }
-//
-//
-// }  // namespace common_lib::communication
+namespace common_lib::communication {
+
+std::vector<common_lib::structures::PathPoint> path_point_array_from_ci_vector(
+    const custom_interfaces::msg::PathPointArray &path_point_array) {
+  std::vector<common_lib::structures::PathPoint> output;
+  for (auto &p : path_point_array.pathpoint_array) {
+    common_lib::structures::PathPoint point;
+    point.position.x = p.x;
+    point.position.y = p.y;
+    point.ideal_velocity = p.v;
+    output.push_back(point);
+  }
+  return output;
+}
+
+} // namespace common_lib::communication

--- a/src/common_lib/src/communication/planning.cpp
+++ b/src/common_lib/src/communication/planning.cpp
@@ -1,7 +1,4 @@
-#include "common_lib/communication/marker.hpp"
-
-#include "rclcpp/clock.hpp"
-#include "rclcpp/rclcpp.hpp"
+#include "common_lib/communication/planning.hpp"
 
 namespace common_lib::communication {
 

--- a/src/mocker_node/CMakeLists.txt
+++ b/src/mocker_node/CMakeLists.txt
@@ -21,6 +21,9 @@ find_package(std_msgs REQUIRED)
 find_package(custom_interfaces REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(fs_msgs REQUIRED)
+find_package(eufs_msgs REQUIRED)
+find_package(common_lib REQUIRED)
+find_package(visualization_msgs REQUIRED)
 
 set(IMPLEMENTATION_FILES
   src/node/mocker_node.cpp
@@ -28,7 +31,7 @@ set(IMPLEMENTATION_FILES
 )
 
 add_executable(mocker_node src/main.cpp ${IMPLEMENTATION_FILES})
-ament_target_dependencies(mocker_node rclcpp std_msgs sensor_msgs custom_interfaces fs_msgs)
+ament_target_dependencies(mocker_node rclcpp std_msgs sensor_msgs custom_interfaces fs_msgs eufs_msgs common_lib visualization_msgs)
 target_include_directories(mocker_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
@@ -46,6 +49,9 @@ find_package(sensor_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(fs_msgs REQUIRED)
+find_package(eufs_msgs REQUIRED)
+find_package(common_lib REQUIRED)
+find_package(visualization_msgs REQUIRED)
 
 set(TESTFILES 
   test/main.cpp
@@ -55,7 +61,7 @@ set(TESTFILES
 include_directories(test)  # Include the 'test' directory for your test targets
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})  # Include the current source directory
 ament_add_gtest(${PROJECT_NAME}_test ${TESTFILES} ${IMPLEMENTATION_FILES})
-ament_target_dependencies(${PROJECT_NAME}_test rclcpp std_msgs sensor_msgs fs_msgs custom_interfaces)
+ament_target_dependencies(${PROJECT_NAME}_test rclcpp std_msgs sensor_msgs fs_msgs eufs_msgs custom_interfaces common_lib visualization_msgs)
 target_include_directories(${PROJECT_NAME}_test PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)

--- a/src/mocker_node/include/node/mocker_node.hpp
+++ b/src/mocker_node/include/node/mocker_node.hpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "common_lib/communication/marker.hpp"
+#include "common_lib/communication/planning.hpp"
 #include "fs_msgs/msg/finished_signal.hpp"
 #include "fs_msgs/msg/go_signal.hpp"
 #include "rclcpp/rclcpp.hpp"

--- a/src/mocker_node/include/node/mocker_node.hpp
+++ b/src/mocker_node/include/node/mocker_node.hpp
@@ -6,15 +6,18 @@
 #include <memory>
 #include <string>
 
+#include "common_lib/communication/marker.hpp"
 #include "fs_msgs/msg/finished_signal.hpp"
 #include "fs_msgs/msg/go_signal.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "utils/mocks.hpp"
+#include "visualization_msgs/msg/marker.hpp"
 
 class MockerNode : public rclcpp::Node {
  private:
   rclcpp::Publisher<custom_interfaces::msg::PathPointArray>::SharedPtr planning_publisher;
   rclcpp::Publisher<custom_interfaces::msg::ConeArray>::SharedPtr se_publisher;
+  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr planning_visualization_publisher;
 
   /**< Timer for the periodic publishing */
   rclcpp::TimerBase::SharedPtr timer_;

--- a/src/mocker_node/package.xml
+++ b/src/mocker_node/package.xml
@@ -16,7 +16,10 @@
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>custom_interfaces</depend>
+  <depend>eufs_msgs</depend>
   <depend>fs_msgs</depend>
+  <depend>common_lib</depend>
+  <depend>visualization_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/mocker_node/src/node/mocker_node.cpp
+++ b/src/mocker_node/src/node/mocker_node.cpp
@@ -26,6 +26,9 @@ MockerNode::MockerNode(const std::string &track_name, const std::string &sim)
       "/state_estimation/mock_map",
       rclcpp::QoS(10).durability(RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL));
 
+  planning_visualization_publisher = this->create_publisher<visualization_msgs::msg::Marker>(
+    "/path_planning/smoothed_mock_path", 10);
+
   this->timer_ = this->create_wall_timer(std::chrono::milliseconds(100),
                                          std::bind(&MockerNode::publish_data, this));
 }
@@ -33,4 +36,8 @@ MockerNode::MockerNode(const std::string &track_name, const std::string &sim)
 void MockerNode::publish_data() {
   planning_publisher->publish(gtruth_planning);
   se_publisher->publish(gtruth_se);
+
+  planning_visualization_publisher->publish(common_lib::communication::line_marker_from_structure_array(
+      common_lib::communication::path_point_array_from_ci_vector(gtruth_planning), "mock_path_planning", "map", 12,
+      "green"));
 }


### PR DESCRIPTION
Just put the function of planning utils in common_lib. Later refactor might deal with planning leftover functions and classes. Can 1 of you test this out in foxglove? my computer is currently not able to do so