### PR TITLE
Slam yaml params

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,6 +30,7 @@ RUN apt update && apt upgrade -y \
     && apt install curl -y \
     && curl -s https://deb.nodesource.com/setup_18.x | sudo bash \
     && apt install nodejs -y \
+    && apt install openjdk-17-jre -y \
     && pip install black \
     && pip install rosbags \
     && apt clean

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -6,11 +6,7 @@
                 "${workspaceFolder}/**",
                 "/opt/ros/humble/include/**",
                 "/usr/include/**",
-<<<<<<< HEAD
                 "/usr/local/include/**"
-=======
-                "/opt/ros/humble/include"
->>>>>>> dev
             ],
             "defines": [],
             "cStandard": "c17",

--- a/config/global/global_config.yaml
+++ b/config/global/global_config.yaml
@@ -3,5 +3,6 @@ global:
   use_simulated_se: false
   use_simulated_perception: false
   use_simulated_planning: false
+  use_simulated_velocities: false
   track_name: "FSE23"
   vehicle_frame_id: "map"

--- a/config/global/global_config.yaml
+++ b/config/global/global_config.yaml
@@ -1,8 +1,9 @@
 global:
-  adapter: "vehicle"
-  use_simulated_se: false
-  use_simulated_perception: false
-  use_simulated_planning: false
-  use_simulated_velocities: false
-  track_name: "FSE23"
-  vehicle_frame_id: "map"
+  adapter: "vehicle" # "vehicle" or "pacsim" or...
+  config_name: "" # version of the configuration, appended to the adapter name on the file name e.g. "_faster_control"
+  use_simulated_se: false # use simulated state estimator from the simulator
+  use_simulated_perception: false # use simulated perception from the simulator
+  use_simulated_planning: false # use simulated planning from the mocker_node
+  use_simulated_velocities: false # use simulated velocities from the simulator
+  track_name: "FSE23" 
+  vehicle_frame_id: "map" # "map" or ... -> frame_id for the visualization messages

--- a/config/slam/pacsim.yaml
+++ b/config/slam/pacsim.yaml
@@ -1,10 +1,10 @@
 slam:
-  motion_model_name: "constant_velocity"
-  data_association_model_name: "maximum_likelihood"
-  data_association_limit_distance: 70
-  observation_x_noise: 0.03
-  observation_y_noise: 0.03
-  velocity_x_noise: 0.01
-  velocity_y_noise: 0.01
-  angular_velocity_noise: 0.01
-  slam_solver: "graph_slam"
+  motion_model_name: "constant_velocity" # "constant_velocity" or ... -> name of the motion model
+  data_association_model_name: "maximum_likelihood" # "maximum_likelihood" or ... -> name of the data association model
+  data_association_limit_distance: 70 # maximum distance to consider a cone for data association
+  observation_x_noise: 0.03 # sigma of the noise for cone positions in x
+  observation_y_noise: 0.03 # sigma of the noise for cone positions in y
+  velocity_x_noise: 0.01 # sigma of the noise for the velocity in x
+  velocity_y_noise: 0.01 # sigma of the noise for the velocity in y
+  angular_velocity_noise: 0.01 # sigma of the noise for the angular velocity
+  slam_solver: "graph_slam" # "graph_slam" or "ekf_slam" or ... -> name of the slam solver

--- a/config/slam/pacsim.yaml
+++ b/config/slam/pacsim.yaml
@@ -1,0 +1,10 @@
+slam:
+  motion_model_name: "constant_velocity"
+  data_association_model_name: "maximum_likelihood"
+  data_association_limit_distance: 70
+  observation_x_noise: 0.03
+  observation_y_noise: 0.03
+  velocity_x_noise: 0.01
+  velocity_y_noise: 0.01
+  angular_velocity_noise: 0.01
+  slam_solver: "graph_slam"

--- a/config/slam/vehicle.yaml
+++ b/config/slam/vehicle.yaml
@@ -1,10 +1,10 @@
 slam:
-  motion_model_name: "constant_velocity"
-  data_association_model_name: "maximum_likelihood"
-  data_association_limit_distance: 70
-  observation_x_noise: 0.03
-  observation_y_noise: 0.03
-  velocity_x_noise: 0.01
-  velocity_y_noise: 0.01
-  angular_velocity_noise: 0.01
-  slam_solver: "graph_slam"
+  motion_model_name: "constant_velocity" # "constant_velocity" or ... -> name of the motion model
+  data_association_model_name: "maximum_likelihood" # "maximum_likelihood" or ... -> name of the data association model
+  data_association_limit_distance: 70 # maximum distance to consider a cone for data association
+  observation_x_noise: 0.03 # sigma of the noise for cone positions in x
+  observation_y_noise: 0.03 # sigma of the noise for cone positions in y
+  velocity_x_noise: 0.01 # sigma of the noise for the velocity in x
+  velocity_y_noise: 0.01 # sigma of the noise for the velocity in y
+  angular_velocity_noise: 0.01 # sigma of the noise for the angular velocity
+  slam_solver: "graph_slam" # "graph_slam" or "ekf_slam" or ... -> name of the slam solver

--- a/config/slam/vehicle.yaml
+++ b/config/slam/vehicle.yaml
@@ -1,0 +1,10 @@
+slam:
+  motion_model_name: "constant_velocity"
+  data_association_model_name: "maximum_likelihood"
+  data_association_limit_distance: 70
+  observation_x_noise: 0.03
+  observation_y_noise: 0.03
+  velocity_x_noise: 0.01
+  velocity_y_noise: 0.01
+  angular_velocity_noise: 0.01
+  slam_solver: "graph_slam"

--- a/src/control/src/node_/node_control.cpp
+++ b/src/control/src/node_/node_control.cpp
@@ -1,10 +1,11 @@
 #include "node_/node_control.hpp"
 
+#include <yaml-cpp/yaml.h>
+
 #include <chrono>
 #include <functional>
 #include <memory>
 #include <string>
-#include <yaml-cpp/yaml.h>
 
 #include "common_lib/communication/marker.hpp"
 #include "common_lib/config_load/config_load.hpp"
@@ -25,21 +26,25 @@ bool received_path_point_array = false;
 
 ControlParameters Control::load_config(std::string& adapter) {
   ControlParameters params;
-  std::string global_config_path = common_lib::config_load::get_config_yaml_path("control", "global", "global_config");
-  RCLCPP_DEBUG(rclcpp::get_logger("control"), "Loading global config from: %s", global_config_path.c_str());
+  std::string global_config_path =
+      common_lib::config_load::get_config_yaml_path("control", "global", "global_config");
+  RCLCPP_DEBUG(rclcpp::get_logger("control"), "Loading global config from: %s",
+               global_config_path.c_str());
   YAML::Node global_config = YAML::LoadFile(global_config_path);
 
   adapter = global_config["global"]["adapter"].as<std::string>();
   params.using_simulated_se_ = global_config["global"]["use_simulated_se"].as<bool>();
   params.use_simulated_planning_ = global_config["global"]["use_simulated_planning"].as<bool>();
 
-
-  std::string control_path = common_lib::config_load::get_config_yaml_path("control", "control", adapter);
-  RCLCPP_DEBUG(rclcpp::get_logger("control"), "Loading control config from: %s", control_path.c_str());
+  std::string control_path =
+      common_lib::config_load::get_config_yaml_path("control", "control", adapter);
+  RCLCPP_DEBUG(rclcpp::get_logger("control"), "Loading control config from: %s",
+               control_path.c_str());
   YAML::Node control = YAML::LoadFile(control_path);
 
   auto control_config = control["control"];
-  RCLCPP_DEBUG(rclcpp::get_logger("control"), "Control config contents: %s", YAML::Dump(control_config).c_str());
+  RCLCPP_DEBUG(rclcpp::get_logger("control"), "Control config contents: %s",
+               YAML::Dump(control_config).c_str());
 
   params.lookahead_gain_ = control_config["lookahead_gain"].as<double>();
   params.pid_kp_ = control_config["pid_kp"].as<double>();

--- a/src/slam/CMakeLists.txt
+++ b/src/slam/CMakeLists.txt
@@ -22,6 +22,7 @@ set(PACKAGES
     message_filters
     motion_lib
     perception_sensor_lib
+    yaml-cpp
 )
 set(GTSAM_INCLUDE_DIRS "/usr/local/include/gtsam")
 foreach(pkg ${PACKAGES})
@@ -45,7 +46,7 @@ set(IMPLEMENTATION_FILES
 )
 
 add_executable(slam src/main.cpp ${IMPLEMENTATION_FILES})
-target_link_libraries(slam tbb gtsam)
+target_link_libraries(slam tbb gtsam yaml-cpp)
 ament_target_dependencies(slam ${PACKAGES})
 target_include_directories(slam PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -78,7 +79,7 @@ if(BUILD_TESTING)
 
   # Unit tests
   ament_add_gtest(slam_test ${TESTFILES} ${IMPLEMENTATION_FILES} TIMEOUT 600)
-  target_link_libraries(slam_test tbb gtsam) # Necessary to be here before Eigen3
+  target_link_libraries(slam_test tbb gtsam yaml-cpp) # Necessary to be here before Eigen3
   ament_target_dependencies(slam_test ${PACKAGES})
   target_include_directories(slam_test PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/src/slam/include/slam_config/general_config.hpp
+++ b/src/slam/include/slam_config/general_config.hpp
@@ -23,5 +23,10 @@ struct SLAMParameters {
   SLAMParameters() = default;
   explicit SLAMParameters(const SLAMParameters &params);
 
-  std::string load_parameters();
+  /**
+   * @brief Load the configuration for the SLAM node from YAML file
+   *
+   * @return std::string adapter_name
+   */
+  std::string load_config();
 };

--- a/src/slam/src/main.cpp
+++ b/src/slam/src/main.cpp
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
   rclcpp::init(argc, argv);
 
   SLAMParameters params;
-  std::string adapter_type = params.load_parameters();
+  std::string adapter_type = params.load_config();
   std::shared_ptr<SLAMNode> slam_node = adapter_map.at(adapter_type)(params);
 
   rclcpp::spin(slam_node);

--- a/src/slam/src/slam_config/general_config.cpp
+++ b/src/slam/src/slam_config/general_config.cpp
@@ -1,5 +1,9 @@
 #include "slam_config/general_config.hpp"
 
+#include <yaml-cpp/yaml.h>
+
+#include "common_lib/config_load/config_load.hpp"
+
 SLAMParameters::SLAMParameters(const SLAMParameters &params) {
   use_simulated_perception_ = params.use_simulated_perception_;
   use_simulated_velocities_ = params.use_simulated_velocities_;
@@ -30,4 +34,34 @@ std::string SLAMParameters::load_parameters() {
   angular_velocity_noise_ = adapter_node->declare_parameter("angular_velocity_noise", 0.03f);
   slam_solver_name_ = adapter_node->declare_parameter("slam_solver", "graph_slam");
   return adapter_node->declare_parameter("adapter", "vehicle");
+}
+
+std::string SLAMParameters::load_config() {
+  std::string global_config_path =
+      common_lib::config_load::get_config_yaml_path("slam", "global", "global_config");
+
+  YAML::Node global_config = YAML::LoadFile(global_config_path);
+
+  std::string adapter = global_config["global"]["adapter"].as<std::string>();
+  this->use_simulated_velocities_ = global_config["global"]["use_simulated_velocities"].as<bool>();
+  this->use_simulated_perception_ = global_config["global"]["use_simulated_perception"].as<bool>();
+
+  std::string slam_config_path =
+      common_lib::config_load::get_config_yaml_path("slam", "slam", adapter);
+
+  YAML::Node slam_config = YAML::LoadFile(slam_config_path);
+
+  this->motion_model_name_ = slam_config["slam"]["motion_model"].as<std::string>();
+  this->data_association_model_name_ =
+      slam_config["slam"]["data_association_model"].as<std::string>();
+  this->data_association_limit_distance_ =
+      slam_config["slam"]["data_association_limit_distance"].as<float>();
+  this->observation_x_noise_ = slam_config["slam"]["observation_x_noise"].as<float>();
+  this->observation_y_noise_ = slam_config["slam"]["observation_y_noise"].as<float>();
+  this->velocity_x_noise_ = slam_config["slam"]["velocity_x_noise"].as<float>();
+  this->velocity_y_noise_ = slam_config["slam"]["velocity_y_noise"].as<float>();
+  this->angular_velocity_noise_ = slam_config["slam"]["angular_velocity_noise"].as<float>();
+  this->slam_solver_name_ = slam_config["slam"]["slam_solver"].as<std::string>();
+
+  return adapter;
 }


### PR DESCRIPTION
@DiogoProPrayer @Davide64-dev @yvesb04 @Flopes55 
- check the way the configuration loading is done by the SLAMParameters structure instead of a static function in the node, which I think looks cleaner
- check the documentation on each parameter in the configuration files. There was documentation in the launch files, and it is fundamental at least for the string parameters 
- @DiogoProPrayer there are duplicate parameter configuration structures in the path planning package, check that out