### PR TITLE
FSF-9067 | Added I component to pure pursuit

### DIFF
--- a/config/control/eufs.yaml
+++ b/config/control/eufs.yaml
@@ -1,6 +1,6 @@
 control:
   lookahead_gain: 0.5
-  lookahead_minimum: 2.0
+  lookahead_minimum: 4
   pid_kp: 0.4
   pid_ki: 0.3
   pid_kd: 0.09
@@ -11,3 +11,6 @@ control:
   pid_anti_windup: 0.7
   lpf_alpha: 1 # Smoothing factor for the low-pass filter (0 = max smoothing, 1 = no smoothing)
   lpf_initial_value: 0.0
+  pp_ki: 0.005
+  pp_anti_windup: 0.5
+  pp_t: 0.01 

--- a/config/control/pacsim.yaml
+++ b/config/control/pacsim.yaml
@@ -1,6 +1,6 @@
 control:
   lookahead_gain: 0.5
-  lookahead_minimum: 2.0
+  lookahead_minimum: 4
   pid_kp: 0.4
   pid_ki: 0.3
   pid_kd: 0.09
@@ -11,3 +11,6 @@ control:
   pid_anti_windup: 0.7
   lpf_alpha: 1 # Smoothing factor for the low-pass filter (0 = max smoothing, 1 = no smoothing)
   lpf_initial_value: 0.0
+  pp_ki: 0.005
+  pp_anti_windup: 0.5
+  pp_t: 0.01 

--- a/config/control/vehicle.yaml
+++ b/config/control/vehicle.yaml
@@ -1,6 +1,6 @@
 control:
   lookahead_gain: 0.5
-  lookahead_minimum: 2.0
+  lookahead_minimum: 4
   pid_kp: 0.4
   pid_ki: 0.3
   pid_kd: 0.09
@@ -11,3 +11,6 @@ control:
   pid_anti_windup: 0.7
   lpf_alpha: 1 # Smoothing factor for the low-pass filter (0 = max smoothing, 1 = no smoothing)
   lpf_initial_value: 0.0
+  pp_ki: 0.005
+  pp_anti_windup: 0.5
+  pp_t: 0.01 

--- a/src/control/include/node_/node_control.hpp
+++ b/src/control/include/node_/node_control.hpp
@@ -36,6 +36,9 @@ struct ControlParameters {
   double pid_anti_windup_;
   double lpf_alpha_;
   double lpf_initial_value_;
+  double pp_ki_;
+  double pp_anti_windup_;
+  double pp_t_;
   std::string map_frame_id_;
 };
 

--- a/src/control/include/pure_pursuit/pp.hpp
+++ b/src/control/include/pure_pursuit/pp.hpp
@@ -22,13 +22,18 @@ constexpr double WHEEL_BASE = 1.5;
  * @details
  * This class implements a Pure Pursuit controller.
  * The two main functions are:
- * - Calculate the lookahead point
- * - Calculate the steering angle (Pure Pursuit Controll Law)
+ * - pp_steering_control_law: Computes the steering angle output
+ * - calculate_alpha: Computes the angle between the vehicle and the lookahead point
  */
 
 class PurePursuit {
 private:
   std::shared_ptr<Filter> lpf_;
+  double ki_;
+  double anti_windup_factor_;
+  double t_;
+  double yaw_integrator_{0.0};
+  double prev_yaw_error_{0.0};
 
 public:
   double max_steering_angle_{MAX_STEERING_ANGLE}; /**< Maximum steering angle */
@@ -39,8 +44,10 @@ public:
    * @brief Construct a new Pure Pursuit object
    *
    * @param lpf Pointer to a low-pass filter
+   * @param ki Integral gain parameter
+   * @param anti_windup_factor Factor to limit the integral term to prevent windup
    */
-  PurePursuit(std::shared_ptr<Filter> lpf);
+  PurePursuit(std::shared_ptr<Filter> lpf, double ki, double anti_windup_factor, double t);
 
   /**
    * @brief Pure Pursuit control law
@@ -49,6 +56,7 @@ public:
    * @param cg
    * @param lookahead_point
    * @param dist_cg_2_rear_axis
+   * @param current_yaw
    *
    * @return Steering angle
    */
@@ -56,7 +64,7 @@ public:
   double pp_steering_control_law(common_lib::structures::Position rear_axis,
                                  common_lib::structures::Position cg,
                                  common_lib::structures::Position lookahead_point,
-                                 double dist_cg_2_rear_axis);
+                                 double dist_cg_2_rear_axis, double current_yaw);
 
   /**
    * @brief Calculate alpha (angle between the vehicle and lookahead point)

--- a/src/control/test/pp_test.cpp
+++ b/src/control/test/pp_test.cpp
@@ -19,7 +19,7 @@ protected:
   void SetUp() override {
     // LPF with alpha=1.0 means no filtering
     lpf_no_effect = std::make_shared<LowPassFilter>(1.0, 0.0);
-    lat_controller_ = std::make_shared<PurePursuit>(lpf_no_effect);
+    lat_controller_ = std::make_shared<PurePursuit>(lpf_no_effect, 0.0, 1.0, 0.0);
   }
 };
 
@@ -111,8 +111,8 @@ TEST_F(PurePursuitTestFixture, Test_pp_steering_control_law_1) {
   Position lookahead_point = Position(1, 4);
   double dist_cg_2_rear_axis = 2.655484889;
 
-  double steering_cmd =
-      lat_controller_->pp_steering_control_law(rear_axis, cg, lookahead_point, dist_cg_2_rear_axis);
+  double steering_cmd = lat_controller_->pp_steering_control_law(rear_axis, cg, lookahead_point,
+                                                                 dist_cg_2_rear_axis, 2.761086);
 
   //  Alpha: 0.804189
   //  ld_: 5.38516


### PR DESCRIPTION
Also increased the minimum lookahead distance, which allows the car to complete the sharp turn in the FSG24 track without significantly increasing the average error.
Additionally, modified the PID controller to track the velocity of the closest path point. This decouples the tuning of the lookahead distance from the velocity, allowing for more optimization.