### PR TITLE
[FSF-8289] - Steering Motor in State Estimation

### DIFF
--- a/src/velocity_estimation/include/estimators/no_rear_wss_ekf.hpp
+++ b/src/velocity_estimation/include/estimators/no_rear_wss_ekf.hpp
@@ -111,11 +111,11 @@ public:
                                                   double steering_angle);
 
   Eigen::Matrix3d compute_steering_jacobian(const Eigen::Vector3d& state,
-                                             const Eigen::Vector3d& velocities,
+                                             const Eigen::Vector3d& accelerations,
                                              double dt, double steering_angle);
 
   Eigen::Vector3d compute_steering_state_update(const Eigen::Vector3d& state,
-                                                 const Eigen::Vector3d& velocities,
+                                                 const Eigen::Vector3d& accelerations,
                                                  double dt, double steering_angle,
                                                  double imu_angular_velocity);
 };

--- a/src/velocity_estimation/include/estimators/no_rear_wss_ekf.hpp
+++ b/src/velocity_estimation/include/estimators/no_rear_wss_ekf.hpp
@@ -55,6 +55,14 @@ class NoRearWSSEKF : public VelocityEstimator {
                const Eigen::Matrix3d& process_noise_matrix, const rclcpp::Time last_update,
                common_lib::sensor_data::ImuData& imu_data);
 
+
+  
+  void predict_with_steering(Eigen::Vector3d& state, Eigen::Matrix3d& covariance,
+                              const Eigen::Matrix3d& process_noise_matrix,
+                              const rclcpp::Time last_update,
+                              const common_lib::sensor_data::ImuData& imu_data,
+                              double steering_angle);
+
   /**
    * @brief Correct the state estimate based on wheel speed sensor, resolver, and steering data.
    *
@@ -98,4 +106,16 @@ public:
    */
   void steering_callback(double steering_angle) override;
   common_lib::structures::Velocities get_velocities() override;
+
+  Eigen::Matrix3d compute_adaptive_process_noise(const Eigen::Matrix3d& base_noise_matrix,
+                                                  double steering_angle);
+
+  Eigen::Matrix3d compute_steering_jacobian(const Eigen::Vector3d& state,
+                                             const Eigen::Vector3d& velocities,
+                                             double dt, double steering_angle);
+
+  Eigen::Vector3d compute_steering_state_update(const Eigen::Vector3d& state,
+                                                 const Eigen::Vector3d& velocities,
+                                                 double dt, double steering_angle,
+                                                 double imu_angular_velocity);
 };


### PR DESCRIPTION
Ter atenção aos seguintes tópicos:
- Ver as contas (ver se a integração do steering angle faz sentido);
- Aonde devo colocar os helpers (as novas funções não devem estar no no_rear_wss_ekf);
- Ver se nova imu_callback faz sentido com aquilo que enviei (se a condição é aquela, ou algo mais restrito);
- O novo predict deve estar separado ou integrado com o predict antigo.

@lourenco31 
Eu encontrei algo estranho enquanto estava a implementar. No predict (VE) é calculado accelerations, mas dentro da função get_jacobian_velocities está velocities. Um dos termos deve estar errado:
![image](https://github.com/user-attachments/assets/aa300868-d978-4b21-9ac7-62c43be2447a)


