### PR TITLE
[FSF-8289] - Steering Motor in State Estimation

### DIFF
--- a/config/velocity_estimation/vehicle.yaml
+++ b/config/velocity_estimation/vehicle.yaml
@@ -8,3 +8,4 @@ velocity_estimation:
   imu_acceleration_noise: 0.1
   imu_rotational_noise: 0.1
   angular_velocity_process_noise: 0.1
+  steering_motor_value_origin: "bosch"   # "bosch" or "cubemars"

--- a/src/velocity_estimation/include/adapters/vehicle_adapter.hpp
+++ b/src/velocity_estimation/include/adapters/vehicle_adapter.hpp
@@ -59,8 +59,15 @@ public:
 
   /**
    * @brief Callback for the subscription of the steering angle sensor
+   * for Bosch vehicles
    */
-  void steering_angle_callback(const custom_interfaces::msg::SteeringAngle msg);
+  void steering_angle_callback_bosch(const custom_interfaces::msg::SteeringAngle msg);
+
+  /**
+    * @brief Callback for the subscription of the steering angle sensor
+    * for Cubemars vehicles
+    */
+  void steering_angle_callback_cubemars(const custom_interfaces::msg::SteeringAngle msg);
 
   /**
    * @brief Callback for the subscription of the resolver which measures the motor RPM

--- a/src/velocity_estimation/include/config/parameters.hpp
+++ b/src/velocity_estimation/include/config/parameters.hpp
@@ -22,6 +22,8 @@ struct VEParameters {
   double steering_angle_noise_;            // Noise to be added to the steering angle measurements
   common_lib::car_parameters::CarParameters car_parameters_;
 
+  std::string steering_motor_value_origin_;  // Origin of the steering motor value, e.g., "bosch" or "cubemars"
+
   /**
    * @brief Load the configuration for the Velocity Estimation node from YAML file
    *

--- a/src/velocity_estimation/src/config/parameters.cpp
+++ b/src/velocity_estimation/src/config/parameters.cpp
@@ -33,6 +33,7 @@ std::string VEParameters::load_config() {
   this->steering_angle_noise_ =
       ve_config["velocity_estimation"]["steering_angle_noise"].as<double>();
   this->motor_rpm_noise_ = ve_config["velocity_estimation"]["motor_rpm_noise"].as<double>();
-
+  this->steering_motor_value_origin_ =
+      ve_config["velocity_estimation"]["steering_motor_value_origin"].as<std::string>();
   return adapter;
 }


### PR DESCRIPTION
Foi adicionada a possibilidade de usar o sensor da cubemars para obter o steering angle. Para trocar basta ir ao vehicle.yaml em velocity_estimation. Foi testado com a VSV Try 6.mcap.

Resultados da Bosh (no código foi colocado o sinal negativo):
![Imagem WhatsApp 2025-07-12 às 19 39 00_bc1b872e](https://github.com/user-attachments/assets/2921389b-d51b-4d8d-90b5-e521032d1fea)

Resultados da cubemars:
![Imagem WhatsApp 2025-07-12 às 19 21 10_007704e4](https://github.com/user-attachments/assets/c9b2dd75-5369-4872-9d21-a10ac6a68ec5)
